### PR TITLE
use XDG_STATE_HOME instead of XDG_LOG_HOME

### DIFF
--- a/dwl-guile/home-service.scm
+++ b/dwl-guile/home-service.scm
@@ -116,9 +116,10 @@ to the '-s' parameter of dwl-guile.")
           #:pid-file #$(string-append (or (getenv "XDG_RUNTIME_DIR")
                                           (format #f "/run/user/~a" (getuid)))
                                       "/dwl-guile.pid")
-          #:log-file #$(string-append (or (getenv "XDG_LOG_HOME")
-                                          (getenv "HOME"))
-                                      "/dwl-guile.log"))))
+          #:log-file #$(format #f "~a/log/dwl-guile.log"
+                           (or (getenv "XDG_STATE_HOME")
+                               (format #f "~a/.local/state"
+                                       (getenv "HOME")))))))
     (stop #~(make-kill-destructor)))))
 
 (define (home-dwl-guile-on-change-service config)


### PR DESCRIPTION
Moves logfile to XDG_STATE_HOME/log/dwl-guile.log

See https://wiki.debian.org/XDGBaseDirectorySpecification